### PR TITLE
Support Java 16 and Format only if needed

### DIFF
--- a/java/git-hooks/pre-commit
+++ b/java/git-hooks/pre-commit
@@ -36,7 +36,19 @@ then
 fi
 
 changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" )
-echo $changed_java_files
-java -jar "$cache_folder/$jar_name" --replace $changed_java_files
-# re add modified java files
-git add $changed_java_files
+
+if [ -z "$changed_java_files=" ] 
+then
+        echo "No java file to format"
+else
+        echo $changed_java_files
+        java \
+          --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+          --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+          -jar "$cache_folder/$jar_name" --replace $changed_java_files
+        # re add modified java files
+        git add $changed_java_files
+fi


### PR DESCRIPTION
support java 16 like explained in the release https://github.com/google/google-java-format/releases/tag/v1.10.0

end reformat only if we have java file to reformat.